### PR TITLE
Battery optimization fix wip issue 51

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <application
         android:allowBackup="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/greenaddress/abcore/ABCoreService.java
+++ b/app/src/main/java/com/greenaddress/abcore/ABCoreService.java
@@ -86,9 +86,12 @@ public class ABCoreService extends Service {
         if (mProcess != null || intent == null)
             return START_STICKY;
         Log.i(TAG, "Core service msg");
+        Log.d(TAG, "onStartCommand: this is ABC core service, where is the best place to add my stuff");
 
         // start core
         try {
+
+            Log.d(TAG, "onStartCommand: starting core");
 
             // allow to pass in a different datadir directory
 

--- a/app/src/main/java/com/greenaddress/abcore/BatteryOptimizationDialog.java
+++ b/app/src/main/java/com/greenaddress/abcore/BatteryOptimizationDialog.java
@@ -1,0 +1,106 @@
+package com.greenaddress.abcore;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.PowerManager;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.util.Log;
+
+import static android.content.Context.POWER_SERVICE;
+
+public class BatteryOptimizationDialog extends DialogFragment {
+
+    private static final String TAG = "BatteryOptimizationDial";
+
+    Context mContext;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        //return super.onCreateDialog(savedInstanceState);
+
+        mContext = getActivity();
+
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        // Set the dialog title
+        builder.setTitle("Please whitelist GreenAddress from Battery Optimization")
+        .setMessage("From android Oreo onward, apps are no longer allowed to run in the background without being whitelisted. GreenAddress needs to run in the background to sync the blockchain. Click accept to be taken to the battery settings page, select All Apps at the top, then turn ABCORE OFF")
+
+                .setPositiveButton("ACCEPT", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        launchSettings();
+                    }
+                });
+        return builder.create();
+    }
+
+    public void launchSettings(){
+
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+        //intent.setData(Uri.parse("package:" + packageName));
+        Log.d(TAG, "onCreate: starting intent");
+        startActivity(intent);
+
+
+
+        final Handler handler2 = new Handler();
+
+        Runnable checkOverlaySetting2 = new Runnable() {
+
+            @Override
+            //@TargetApi(23)
+            public void run() {
+                Log.d(TAG, "run: 1");
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                    Log.d(TAG, "run: 2");
+                    //return;
+                }
+
+                // 18th Jan 2018, below works, trying to stop using the intent ( ie try back button below).
+                if (checkBatteryOptimizations()) {
+                    Log.d(TAG, "run: 41");
+                    Log.d(TAG, "run: Notificiation Enabled moterfucker");
+                    //You have the permission, re-launch MainActivity
+                    Intent i = new Intent(mContext, MainActivity.class);
+                    Log.d(TAG, "run: 42");
+                    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                    mContext.startActivity(i);
+                    //Log.d(TAG, "the activity is: " + getActivity());
+                    return;
+                }
+
+                // 2018-10-10 21:10:28.927 18918f height=299594 version=0x00000002 log2_work=78.451656 tx=38300079 date='2014-05-07T19:32:00Z' progress=0.110530 cache=35.6MiB(188505txo)
+
+                handler2.postDelayed(this, 200);
+            }
+        };
+
+        handler2.postDelayed(checkOverlaySetting2, 1000);
+
+
+    }
+
+    public boolean checkBatteryOptimizations(){
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+
+            String packageName = mContext.getPackageName();
+            PowerManager pm = (PowerManager)mContext.getSystemService(POWER_SERVICE);
+
+            return pm.isIgnoringBatteryOptimizations(packageName);
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/greenaddress/abcore/BatteryOptimizationDialog.java
+++ b/app/src/main/java/com/greenaddress/abcore/BatteryOptimizationDialog.java
@@ -15,6 +15,14 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
 
+/**
+ * Dialog that opens to explain the changes the user, then open the Android Battery Optimization
+ * general page. Note the user will have to make several steps to complete:
+ *
+ * 1 - switch the setting from "Show Unoptimized apps" to "Show all apps"
+ * 2 - toggle the setting for ABCore
+ */
+
 import static android.content.Context.POWER_SERVICE;
 
 public class BatteryOptimizationDialog extends DialogFragment {
@@ -32,10 +40,11 @@ public class BatteryOptimizationDialog extends DialogFragment {
 
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        // Set the dialog title
-        builder.setTitle("Please whitelist GreenAddress from Battery Optimization")
-        .setMessage("From android Oreo onward, apps are no longer allowed to run in the background without being whitelisted. GreenAddress needs to run in the background to sync the blockchain. Click accept to be taken to the battery settings page, select All Apps at the top, then turn ABCORE OFF")
-
+        // Set the dialog title - I'll move these to Strings values latter, once we decide what to say
+        builder.setTitle("Please whitelist ABCore from Battery Optimization")
+        .setMessage("From android Marshmallow onward, apps are no longer allowed to run in the background " +
+                "without being whitelisted. ABCore needs to run in the background to sync the blockchain. " +
+                "Click accept to be taken to the battery settings page, select All Apps at the top, then turn ABCORE OFF")
                 .setPositiveButton("ACCEPT", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
@@ -54,9 +63,11 @@ public class BatteryOptimizationDialog extends DialogFragment {
         startActivity(intent);
 
 
+        /**
+         * Handler which checks the settings every 200 milliseconds
+         */
 
         final Handler handler2 = new Handler();
-
         Runnable checkOverlaySetting2 = new Runnable() {
 
             @Override
@@ -64,41 +75,34 @@ public class BatteryOptimizationDialog extends DialogFragment {
             public void run() {
                 Log.d(TAG, "run: 1");
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-                    Log.d(TAG, "run: 2");
-                    //return;
-                }
-
-                // 18th Jan 2018, below works, trying to stop using the intent ( ie try back button below).
-                if (checkBatteryOptimizations()) {
-                    Log.d(TAG, "run: 41");
-                    Log.d(TAG, "run: Notificiation Enabled moterfucker");
-                    //You have the permission, re-launch MainActivity
-                    Intent i = new Intent(mContext, MainActivity.class);
-                    Log.d(TAG, "run: 42");
-                    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                    mContext.startActivity(i);
-                    //Log.d(TAG, "the activity is: " + getActivity());
+                    Log.d(TAG, "skipping, not needed");
                     return;
                 }
-
-                // 2018-10-10 21:10:28.927 18918f height=299594 version=0x00000002 log2_work=78.451656 tx=38300079 date='2014-05-07T19:32:00Z' progress=0.110530 cache=35.6MiB(188505txo)
-
+                if (checkBatteryOptimizations()) {
+                    //You have the permission, re-launch MainActivity
+                    Intent i = new Intent(mContext, MainActivity.class);
+                    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                    mContext.startActivity(i);
+                    return;
+                }
                 handler2.postDelayed(this, 200);
             }
         };
-
         handler2.postDelayed(checkOverlaySetting2, 1000);
 
 
     }
+    /**
+     * Check to see if the battery optimization has been turned off. Used in the handler above, so that the user will automatically
+     * be taken back to app when the setting is turned off. Solves random back issues when stepping through Android Settings menus
+     */
+
 
     public boolean checkBatteryOptimizations(){
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-
             String packageName = mContext.getPackageName();
             PowerManager pm = (PowerManager)mContext.getSystemService(POWER_SERVICE);
-
             return pm.isIgnoringBatteryOptimizations(packageName);
         }
         return true;

--- a/app/src/main/java/com/greenaddress/abcore/MainActivity.java
+++ b/app/src/main/java/com/greenaddress/abcore/MainActivity.java
@@ -5,8 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.preference.PreferenceManager;
+import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -93,6 +96,28 @@ public class MainActivity extends AppCompatActivity {
         mProgressBar = findViewById(R.id.progressBar);
         setSupportActionBar(toolbar);
         setSwitch();
+
+
+
+        // first attempt at fix:
+
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Log.d(TAG, "onCreate: starting battery optimization");
+
+            String packageName = getPackageName();
+            PowerManager pm = (PowerManager) getSystemService(POWER_SERVICE);
+
+            boolean battery = pm.isIgnoringBatteryOptimizations(packageName);
+            Log.d(TAG, "onCreate: battery booolean is: " + battery);
+            if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+                Log.d(TAG, "onCreate: not ignoring ");
+                launchBatteryOptimizationDialog();
+            }
+
+
+            Log.d(TAG, "onCreate: after launch the boolean is: " + pm.isIgnoringBatteryOptimizations(packageName));
+        }
     }
 
     @Override
@@ -174,5 +199,18 @@ public class MainActivity extends AppCompatActivity {
                     postConfigure();
             }
         }
+    }
+
+    public void launchBatteryOptimizationDialog(){
+
+        DialogFragment batteryOpt = new BatteryOptimizationDialog();
+        batteryOpt.setCancelable(false);
+        batteryOpt.show(getSupportFragmentManager(), "battery");
+
+
+
+
+
+
     }
 }

--- a/app/src/main/java/com/greenaddress/abcore/MainActivity.java
+++ b/app/src/main/java/com/greenaddress/abcore/MainActivity.java
@@ -98,12 +98,15 @@ public class MainActivity extends AppCompatActivity {
         setSwitch();
 
 
-
-        // first attempt at fix:
+        /**
+         * Basic fix before we decide how to do it
+         * We could leave like this, and automatically ask every user - PROBABLY NOT RECOMMENDED
+         * This change IS NOT needed for people plugged into power, Doze mode does not activate on battery power ( mostly, some manufacturers cannot be trusted)
+         * I would suggest another toggle, like the ON SWITCH, or alternatively, we could add it as an option in settings
+         */
 
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Log.d(TAG, "onCreate: starting battery optimization");
 
             String packageName = getPackageName();
             PowerManager pm = (PowerManager) getSystemService(POWER_SERVICE);
@@ -114,8 +117,6 @@ public class MainActivity extends AppCompatActivity {
                 Log.d(TAG, "onCreate: not ignoring ");
                 launchBatteryOptimizationDialog();
             }
-
-
             Log.d(TAG, "onCreate: after launch the boolean is: " + pm.isIgnoringBatteryOptimizations(packageName));
         }
     }
@@ -201,16 +202,12 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    // method to launch the dialog
+
     public void launchBatteryOptimizationDialog(){
 
         DialogFragment batteryOpt = new BatteryOptimizationDialog();
         batteryOpt.setCancelable(false);
         batteryOpt.show(getSupportFragmentManager(), "battery");
-
-
-
-
-
-
     }
 }

--- a/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
+++ b/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
@@ -29,7 +29,11 @@ public class RPCIntentService extends IntentService {
     private static final String TAG = RPCIntentService.class.getName();
 
     public RPCIntentService() {
+
+
         super(RPCIntentService.class.getName());
+
+        Log.d(TAG, "RPCIntentService: in constructor 1");
     }
 
     private Properties getBitcoinConf() throws IOException {


### PR DESCRIPTION
So this is working code to give you an idea of what the user will be required to do. At the moment the dialog will pop up as soon as the user has set the switch to download Core.

This is probably NOT what I would recommend - if the user is using an Android device that is left plugged in, there is no need for this fix, as Doze is not supposed to activate when plugged in ( there are some phones which ignore this, for no particular rhyme or reason). I would recommend either:
a) another toggle under the "On / Off Switch" on Main Activity, or
b) add it as an option in the settings menu.

It depends where we want to educate the user I guess. They might not find it in the settings, but cluttering the MainActivity UI/UX is rarely a good idea.

I am happy to implement either, just let me know what you prefer.