### PR TITLE
Use SUPPORTED_ABIS to determine the correct binary

### DIFF
--- a/app/src/main/java/com/greenaddress/abcore/DownloadActivity.java
+++ b/app/src/main/java/com/greenaddress/abcore/DownloadActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -47,9 +48,9 @@ public class DownloadActivity extends AppCompatActivity {
 
         try {
             Utils.getArch();
-        } catch (final Utils.UnsupportedArch e) {
+        } catch (final Utils.ABIsUnsupported e) {
             mButton.setEnabled(false);
-            final String msg = getString(R.string.archunsupported, e.arch);
+            final String msg = getString(R.string.abis_unsupported, TextUtils.join(",", e.supported_ABIs));
             mTvStatus.setText(msg);
             showSnackMsg(msg);
         }

--- a/app/src/main/java/com/greenaddress/abcore/Utils.java
+++ b/app/src/main/java/com/greenaddress/abcore/Utils.java
@@ -1,6 +1,7 @@
 package com.greenaddress.abcore;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.Log;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -114,16 +115,19 @@ class Utils {
     }
 
     static String getArch() {
-        final String arch = System.getProperty("os.arch");
-        if (arch.endsWith("86"))
-            return "i686-linux-android";
-        else if (arch.startsWith("armv7"))
-            return "arm-linux-androideabi";
-        else if (arch.endsWith("86_64"))
-            return "x86_64-linux-android";
-        else if ("aarch64".equals(arch) || "armv8l".equals(arch))
-            return "aarch64-linux-android";
-        throw new UnsupportedArch(arch);
+        for (String abi : Build.SUPPORTED_ABIS) {
+            switch (abi) {
+                case "armeabi-v7a":
+                    return "arm-linux-androideabi";
+                case "arm64-v8a":
+                    return "aarch64-linux-android";
+                case "x86":
+                    return "i686-linux-android";
+                case "x86_64":
+                    return "x86_64-linux-android";
+            }
+        }
+        throw new ABIsUnsupported(Build.SUPPORTED_ABIS);
     }
 
     static File getDir(final Context c) {
@@ -176,12 +180,12 @@ class Utils {
         void update(final int bytesPerSecond, final int bytesDownloaded);
     }
 
-    static class UnsupportedArch extends RuntimeException {
-        final String arch;
+    static class ABIsUnsupported extends RuntimeException {
+        final String[] supported_ABIs;
 
-        UnsupportedArch(final String a) {
-            super(UnsupportedArch.class.getName());
-            this.arch = a;
+        ABIsUnsupported(final String[] s) {
+            super(ABIsUnsupported.class.getName());
+            this.supported_ABIs = s;
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="archunsupported">Architektur %1$s wird nicht unterstützt.@</string>
     <string name="download_core">Die App benötigt Bitcoin zum Funktionieren. Betätigen Sie die Schaltfläche um den Download und die Konfigurierung von Bitcoin zu beginnen.</string>
     <string name="failedretry">Fehler. Erneut versuchen?</string>
     <string name="pleasewait">"Bitte haben Sie etwas Geduld, während der Kern gesucht wird…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -11,7 +11,6 @@
     <string name="start">Télécharger</string>
     <string name="failedretry">Échec, voulez-vous réessayer?</string>
     <string name="waitfetchingconfiguring">Veuillez patienter, récupération, déballage et configuration de Bitcoin&#8230;</string>
-    <string name="archunsupported">L\'architecture %1$s n\'est pas supportée</string>
     <string name="runningturnoff">Bitcoin %1$s %2$s est en cours d\'exécution, désactivez-le pour l\'arrêter.</string>
     <string name="stoppedturnon">"Bitcoin %1$s %2$s n\'est pas en cours d\'exécution, activez-le pour le démarrer."</string>
     <string name="switchcoreon">Activer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,7 +11,6 @@
     <string name="start">Fai partire il download</string>
     <string name="failedretry">Fallito, vuoi riprovare?</string>
     <string name="waitfetchingconfiguring">Per piacere aspetta. Scaricamento e configurazione di Bitcoin &#8230;</string>
-    <string name="archunsupported">Il dispostivo %1$s non è supportato</string>
     <string name="runningturnoff">Bitcoin %1$s %2$s è partito, porta Core su OFF per fermarlo.</string>
     <string name="stoppedturnon">"Bitcoin %1$s %2$s non è in funzione, porta Core su ON per farlo partire"</string>
     <string name="switchcoreon">Porta Core ON</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="start">Start download</string>
     <string name="failedretry">Failure, want to retry?</string>
     <string name="waitfetchingconfiguring">Please wait. Fetching, unpacking and configuring Bitcoin&#8230;</string>
-    <string name="archunsupported">Architecture %1$s is not supported</string>
+    <string name="abis_unsupported">The Application Binary Interfaces supported by this device aren\'t suppored by ABCore: %1$s</string>
     <string name="runningturnoff">Bitcoin %1$s %2$s is running, please switch OFF to stop it.</string>
     <string name="stoppedturnon">"Bitcoin %1$s %2$s is not running, please switch ON to start it."</string>
     <string name="switchcoreon">Switch ON</string>


### PR DESCRIPTION
Previously ABCore attempted to determine the correct binary to download by the CPU architecture (returned by `System.getProperty("os.arch")`).

However, some devices have a 64-bit processor with a 32-bit OS installed. This was observed on a Xiaomi Mi Box S (Android TV device) and the same is probably true for Amazon Fire TV devices, however I don't have one to test it.

On such devices, ABCore used to fetch the wrong binary and `bitcoind` would fail to launch. This PR fixes the issue by querying `Build.SUPPORTED_ABIS` instead, which lists all ABIs supported by the device by order of preference.

I tested this patch on a Xiaomi Mi Box S (arm64 processor, 32-bit OS), and a Samsung Galaxy S7 Edge (European/Exynos version, arm64 processor, 64-bit OS). The correct binary was downloaded for both.

I didn't have x86/x64 devices to test on, perhaps it would be best to test on those devices before merging this. The strings used for the ABIs are detailed in [Google's documentation](https://developer.android.com/ndk/guides/abis#sa).

Also updated the error message when no binary matches the supported ABIs. There's only the English strings, I didn't add any translation.