### PR TITLE
Use foreground service for bitcoind instead of background service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/greenaddress/abcore/ABCoreService.java
+++ b/app/src/main/java/com/greenaddress/abcore/ABCoreService.java
@@ -39,7 +39,7 @@ public class ABCoreService extends Service {
         return null;
     }
 
-    private void setupNotification() {
+    private void setupNotificationAndMoveToForeground() {
         final Intent i = new Intent(this, MainActivity.class);
         i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
                 Intent.FLAG_ACTIVITY_CLEAR_TASK);
@@ -72,7 +72,7 @@ public class ABCoreService extends Service {
 
         final Notification n = b.build();
 
-        nM.notify(NOTIFICATION_ID, n);
+        startForeground(NOTIFICATION_ID, n);
 
         final Intent broadcastIntent = new Intent();
         broadcastIntent.setAction(MainActivity.RPCResponseReceiver.ACTION_RESP);
@@ -125,7 +125,7 @@ public class ABCoreService extends Service {
             errorGobbler.start();
             outputGobbler.start();
 
-            setupNotification();
+            setupNotificationAndMoveToForeground();
 
         } catch (final IOException e) {
             Log.i(TAG, "Native exception!");

--- a/app/src/main/java/com/greenaddress/abcore/MainActivity.java
+++ b/app/src/main/java/com/greenaddress/abcore/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
@@ -72,7 +73,11 @@ public class MainActivity extends AppCompatActivity {
                     final SharedPreferences.Editor e = prefs.edit();
                     e.putBoolean("magicallystarted", false);
                     e.apply();
-                    startService(new Intent(MainActivity.this, ABCoreService.class));
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        startForegroundService(new Intent(MainActivity.this, ABCoreService.class));
+                    } else {
+                        startService(new Intent(MainActivity.this, ABCoreService.class));
+                    }
                 }
                 else {
                     final Intent i = new Intent(MainActivity.this, RPCIntentService.class);


### PR DESCRIPTION
This upgrades `ABCoreService` to a foreground service, which is designed for services that users are "aware of" (like playing music), and are therefore allowed to stay alive even when battery optimization is on.

The only requirement is that a notification is showed to the user to make them aware of the service - there's no change in behavior because ABCore already did that.

The `FOREGROUND_SERVICE` permission is required from Android 9. It's a "normal permission" so it's granted automatically without prompting the user.

While this overrides "battery optimization" settings, some devices also support "battery use _restriction_", which won't allow foreground services to stay alive. However this setting is opt-in and isn't enabled by default, and users are warned that it may break the app - so that's a clear improvement.

Tested on Pixel XL (9.0), Xiaomi Mi Box S (TV 8.1), Galaxy S7 Edge (8.0)