### PR TITLE
Target Android 9, to allow Android 10 devices to execute binaries from app home dir

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "com.greenaddress.abcore"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 74
         versionName "0.74"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Android 10 won't allow apps targeting Android 10 to excute binaries from its app home directory. Currently this causes ABCore on Android 10 to fail launching `tor` and `bitcoind` and crash soon afterwards.

This PR rolls back ABCore to target Android 9 (API level 28) in order to fix this temporarily. See issue #97 for more details and discussion of future options