### PR TITLE
Avoid infinite loop if daemon is not responding.

### DIFF
--- a/app/src/main/java/com/greenaddress/abcore/MainActivity.java
+++ b/app/src/main/java/com/greenaddress/abcore/MainActivity.java
@@ -278,6 +278,10 @@ public class MainActivity extends AppCompatActivity {
                     }
                     //for mDaemonStatus = STOPPED we don't have to do anything
                     break;
+                case "stopped":
+                    mDaemonStatus = DaemonStatus.STOPPED;
+                    mTvStatus.setText(getString(R.string.status_header, mDaemonStatus.toString()));
+                    break;
                 case "localonion":
                     if (mDaemonStatus == DaemonStatus.STARTING || mDaemonStatus == DaemonStatus.UNKNOWN){
                         mDaemonStatus = DaemonStatus.RUNNING;
@@ -318,6 +322,9 @@ public class MainActivity extends AppCompatActivity {
                     pb.setMax(max);
                     pb.setProgress(percent);
                     textStatus.setText(getString(R.string.progress_bar_message, percent, blocks));
+                    break;
+                default:
+                    Log.e(TAG, "Unexpected broadcast result - " + text);
             }
         }
     }

--- a/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
+++ b/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
@@ -177,6 +177,11 @@ public class RPCIntentService extends IntentService {
                     getRpc().stop();
                     break;
                 } catch (final BitcoinRPCException | IOException e) {
+                    if (e instanceof BitcoinRPCException && ((BitcoinRPCException) e).getResponse() == null) {
+                        Log.e(TAG, "daemon not responding, already stopped");
+                        broadcastError(e);
+                        break;
+                    }
                     try {
                         Thread.sleep(200);
                     } catch (final InterruptedException e1) {

--- a/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
+++ b/app/src/main/java/com/greenaddress/abcore/RPCIntentService.java
@@ -155,6 +155,14 @@ public class RPCIntentService extends IntentService {
         sendBroadcast(broadcastIntent);
     }
 
+    private void broadcastStop() {
+        Log.e(TAG, "broadcastStop");
+        final Intent broadcastIntent = new Intent();
+        broadcastIntent.setAction(MainActivity.RPCResponseReceiver.ACTION_RESP);
+        broadcastIntent.addCategory(Intent.CATEGORY_DEFAULT);
+        broadcastIntent.putExtra(PARAM_OUT_MSG, "stopped");
+        sendBroadcast(broadcastIntent);
+    }
 
     @Override
     protected void onHandleIntent(final Intent intent) {
@@ -175,6 +183,7 @@ public class RPCIntentService extends IntentService {
             while (true) {
                 try {
                     getRpc().stop();
+                    broadcastStop();
                     break;
                 } catch (final BitcoinRPCException | IOException e) {
                     if (e instanceof BitcoinRPCException && ((BitcoinRPCException) e).getResponse() == null) {
@@ -182,6 +191,7 @@ public class RPCIntentService extends IntentService {
                         broadcastError(e);
                         break;
                     }
+                    Log.v(TAG, "stop failed, looping back");
                     try {
                         Thread.sleep(200);
                     } catch (final InterruptedException e1) {


### PR DESCRIPTION
After some tests I found 2 sources of issues.

1 - If the daemon stops and after that the RPC gets a stop command, it enters an infinite loop of calling stop
@greenaddress do you know why this loop was introduced? Is it really necessary?

2 - getNetworkInfo() might get stuck, causing the Service also get stuck and to not respond to new requests. I still need to investigate this one better so I just added a TODO for now.